### PR TITLE
Get packages version from mirrors before upgrade

### DIFF
--- a/dev-project/devstack.yaml
+++ b/dev-project/devstack.yaml
@@ -112,6 +112,7 @@ resources:
                       enable_plugin ceilometer-infoblox https://github.com/$fork_name/ceilometer-infoblox.git $branch_name
 
             runcmd:
+              - apt-get update
               - apt-get -y --force-yes upgrade
               - echo infoblox > /tmp/pw
               - echo infoblox >> /tmp/pw


### PR DESCRIPTION
Having outdated info about packages versions available in mirrors causes failures on attempt to install package. In this case git failed to install because requested (old) version was already removed from package mirrors.
